### PR TITLE
Two tweaks relating to scan.packages

### DIFF
--- a/guice/common/src/main/java/com/peterphi/std/guice/apploader/impl/GuiceFactory.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/apploader/impl/GuiceFactory.java
@@ -104,7 +104,7 @@ class GuiceFactory
 			if (packages != null && !packages.isEmpty())
 				scannerFactory = new ClassScannerFactory(packages.toArray(new String[packages.size()]));
 			else
-				throw new IllegalArgumentException("No ClassScanner specified!");
+				throw new IllegalArgumentException("Property " + GuiceProperties.SCAN_PACKAGES + " has not been set!");
 		}
 
 		final GuiceSetup setup;

--- a/guice/sample-rest-service/src/main/resources/service.properties
+++ b/guice/sample-rest-service/src/main/resources/service.properties
@@ -1,3 +1,4 @@
 restutils.show-serviceprops=true
 guice.bootstrap.class=com.peterphi.std.guice.testrestclient.guice.Setup
+scan.packages=com.peterphi.std.guice.testrestclient
 


### PR DESCRIPTION
I have added the property scan.packages to the sample rest service projects service.properties as it is required for the Web application to start correctly.

I also changed the error message thrown when scan.packages hasn't been set; so it is now obvious to the end user that the property needs to be set.