### PR TITLE
Log prepared SQL queries for WebQuery execution

### DIFF
--- a/guice/common/src/main/java/com/peterphi/std/guice/restclient/jaxb/webquery/WQUriControlField.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/restclient/jaxb/webquery/WQUriControlField.java
@@ -1,5 +1,9 @@
 package com.peterphi.std.guice.restclient.jaxb.webquery;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Special WebQuery fields and their wire representation in the Query String API
  */
@@ -18,6 +22,10 @@ public enum WQUriControlField
 	 * Set to true to request the resultset size be computed
 	 */
 	COMPUTE_SIZE("_compute_size"),
+	/**
+	 * Set to true to request that the SQL prepared statements as a result of this query be recorded as part of the resultset
+	 */
+	LOG_SQL("_log_sql"),
 	/**
 	 * Set to some class to specify the subclass to return (for entities with type hierarchies)
 	 */
@@ -63,5 +71,16 @@ public enum WQUriControlField
 		}
 
 		throw new IllegalArgumentException("No core WebQueryField with name: " + fieldName);
+	}
+
+
+	/**
+	 * Return all the permitted names
+	 *
+	 * @return
+	 */
+	public static List<String> getAllNames()
+	{
+		return Arrays.asList(values()).stream().map(o -> o.getName()).collect(Collectors.toList());
 	}
 }

--- a/guice/common/src/main/java/com/peterphi/std/guice/restclient/jaxb/webquery/WebQuery.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/restclient/jaxb/webquery/WebQuery.java
@@ -39,6 +39,9 @@ public class WebQuery
 	@XmlAttribute
 	public String expand = "all";
 
+	@XmlAttribute
+	public boolean logSQL = false;
+
 	@XmlElement
 	public WQConstraints constraints = new WQConstraints();
 
@@ -89,14 +92,28 @@ public class WebQuery
 	}
 
 
+	public boolean isLogSQL()
+	{
+		return this.logSQL;
+	}
+
+
 	@Override
 	public String toString()
 	{
 		return "WebQuery{" +
-		       "fetch='" + fetch + '\'' +
-		       ", expand='" + expand + '\'' +
-		       ", constraints=" + constraintsToQueryFragment() +
-		       ", orderings=" + orderings +
+		       "fetch='" +
+		       fetch +
+		       '\'' +
+		       ", expand='" +
+		       expand +
+		       '\'' +
+		       ", constraints=" +
+		       constraintsToQueryFragment() +
+		       ", logSQL=" +
+		       logSQL +
+		       ", orderings=" +
+		       orderings +
 		       '}';
 	}
 
@@ -185,6 +202,13 @@ public class WebQuery
 		return this;
 	}
 
+
+	public WebQuery logSQL(final boolean enabled)
+	{
+		this.logSQL = enabled;
+
+		return this;
+	}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Constraints
@@ -454,6 +478,8 @@ public class WebQuery
 					case COMPUTE_SIZE:
 						def.computeSize(parseBoolean(entry.getValue().get(0)));
 						break;
+					case LOG_SQL:
+						def.logSQL(parseBoolean(entry.getValue().get(0)));
 					case EXPAND:
 						def.expand(entry.getValue().toArray(new String[entry.getValue().size()]));
 						break;
@@ -465,7 +491,7 @@ public class WebQuery
 						def.fetch(entry.getValue().stream().collect(Collectors.joining(",")));
 						break;
 					default:
-						throw new IllegalArgumentException("Unknown query field: " + specialField);
+						throw new IllegalArgumentException("Unknown query field: " + specialField + " expected one of " + WQUriControlField.getAllNames());
 				}
 			}
 			else
@@ -488,10 +514,11 @@ public class WebQuery
 
 					group.operator = WQGroupType.OR;
 
-					group.constraints = entry.getValue()
-					                         .stream()
-					                         .map(value -> WQConstraint.decode(entry.getKey(), value))
-					                         .collect(Collectors.toList());
+					group.constraints = entry
+							                    .getValue()
+							                    .stream()
+							                    .map(value -> WQConstraint.decode(entry.getKey(), value))
+							                    .collect(Collectors.toList());
 
 					def.constraints.constraints.add(group);
 				}
@@ -505,10 +532,12 @@ public class WebQuery
 
 	private static boolean parseBoolean(String value)
 	{
-		if (StringUtils.equalsIgnoreCase(value, "true") || StringUtils.equalsIgnoreCase(value, "yes") ||
+		if (StringUtils.equalsIgnoreCase(value, "true") ||
+		    StringUtils.equalsIgnoreCase(value, "yes") ||
 		    StringUtils.equalsIgnoreCase(value, "on"))
 			return true;
-		else if (StringUtils.equalsIgnoreCase(value, "false") || StringUtils.equalsIgnoreCase(value, "no") ||
+		else if (StringUtils.equalsIgnoreCase(value, "false") ||
+		         StringUtils.equalsIgnoreCase(value, "no") ||
 		         StringUtils.equalsIgnoreCase(value, "off"))
 			return false;
 		else

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/module/logging/HibernateObservingInterceptor.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/module/logging/HibernateObservingInterceptor.java
@@ -1,0 +1,134 @@
+package com.peterphi.std.guice.hibernate.module.logging;
+
+import com.google.inject.Singleton;
+import org.hibernate.EmptyInterceptor;
+import org.hibernate.Interceptor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ * Uses hibernate's {@link Interceptor} class behind the scenes to allow observers to hook into events (N.B. but not alter them)
+ */
+@Singleton
+public class HibernateObservingInterceptor
+{
+	private HibernateInterceptorImpl instance;
+
+	private ThreadLocal<List<Consumer<String>>> onPrepareStatementWatchers = new ThreadLocal<>();
+
+
+	public HibernateObservingInterceptor()
+	{
+		instance = new HibernateInterceptorImpl(this);
+	}
+
+
+	public Interceptor getInterceptor()
+	{
+		return instance;
+	}
+
+
+	private void onPrepareStatement(String sql)
+	{
+		final List<Consumer<String>> consumers = onPrepareStatementWatchers.get();
+
+		if (consumers != null)
+		{
+			for (Consumer<String> consumer : consumers)
+			{
+				consumer.accept(sql);
+			}
+		}
+	}
+
+
+	/**
+	 * Start a new logger which records SQL Prepared Statements created by Hibernate in this Thread. Must be closed (or treated as
+	 * autoclose)
+	 *
+	 * @return
+	 */
+	public HibernateSQLLogger startSQLLogger()
+	{
+		final HibernateSQLLogger logger = new HibernateSQLLogger(this);
+
+		logger.start();
+
+		return logger;
+	}
+
+
+	/**
+	 * Add an observer to <code>onPrepareStatement</code> calls made by the current Thread until {@link
+	 * #clearThreadLocalObservers()} is
+	 * called
+	 *
+	 * @param observer
+	 */
+	public void addThreadLocalSQLAuditor(Consumer<String> observer)
+	{
+		List<Consumer<String>> observers = onPrepareStatementWatchers.get();
+
+		if (observers == null)
+		{
+			observers = new CopyOnWriteArrayList<>();
+			onPrepareStatementWatchers.set(observers);
+		}
+
+		observers.add(observer);
+	}
+
+
+	/**
+	 * Remove a previously added observer for <code>onPrepareStatement</code> calls
+	 *
+	 * @param observer
+	 */
+	public void removeThreadLocalSQLAuditor(Consumer<String> observer)
+	{
+		List<Consumer<String>> observers = onPrepareStatementWatchers.get();
+
+		observers.remove(observer);
+
+		if (observers.isEmpty())
+			onPrepareStatementWatchers.remove();
+	}
+
+
+	/**
+	 * Clear any Thread Local observers
+	 */
+	public void clearThreadLocalObservers()
+	{
+		onPrepareStatementWatchers.remove();
+	}
+
+
+	/**
+	 * The hibernate interceptor; extends EmptyInterceptor because we are only observing
+	 */
+	private static class HibernateInterceptorImpl extends EmptyInterceptor
+	{
+		private final HibernateObservingInterceptor parent;
+
+
+		public HibernateInterceptorImpl(final HibernateObservingInterceptor parent)
+		{
+			this.parent = parent;
+		}
+
+
+		@Override
+		public String onPrepareStatement(String sql)
+		{
+			// Notify the observers
+			parent.onPrepareStatement(sql);
+
+			// Return unmodified
+			return sql;
+		}
+	}
+}

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/module/logging/HibernateSQLLogger.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/module/logging/HibernateSQLLogger.java
@@ -1,0 +1,60 @@
+package com.peterphi.std.guice.hibernate.module.logging;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Uses a Hibernate {@link org.hibernate.Interceptor} to intercept SQL Statement preparations as they happen on the local thread
+ */
+public class HibernateSQLLogger implements Closeable, AutoCloseable, Consumer<String>
+{
+	private final List<String> statements = new ArrayList<>(0);
+	private final HibernateObservingInterceptor interceptor;
+
+
+	public HibernateSQLLogger(HibernateObservingInterceptor interceptor)
+	{
+		this.interceptor = interceptor;
+	}
+
+
+	public void start()
+	{
+		interceptor.addThreadLocalSQLAuditor(this);
+	}
+
+
+	@Override
+	public void accept(final String sql)
+	{
+		synchronized (statements)
+		{
+			statements.add(sql);
+		}
+	}
+
+
+	@Override
+	public void close()
+	{
+		interceptor.removeThreadLocalSQLAuditor(this);
+	}
+
+
+	/**
+	 * Return a read-only copy of the statements prepared since this logger was started and before the logger was stopped; if the
+	 * logger has not yet been stopped then it will return the statements prepared thus far
+	 *
+	 * @return
+	 */
+	public List<String> getAllStatements()
+	{
+		synchronized (statements)
+		{
+			return Collections.unmodifiableList(new ArrayList<>(statements));
+		}
+	}
+}

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/ConstrainedResultSet.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/ConstrainedResultSet.java
@@ -2,12 +2,14 @@ package com.peterphi.std.guice.hibernate.webquery;
 
 import com.peterphi.std.guice.restclient.jaxb.webquery.WebQuery;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ConstrainedResultSet<T>
 {
 	protected /*final*/ ResultSetConstraint constraint;
 	protected /*final*/ WebQuery query;
+	protected List<String> sql = Collections.emptyList();
 	protected final List<T> list;
 
 	protected Long total;
@@ -91,5 +93,17 @@ public class ConstrainedResultSet<T>
 	public void setTotal(final Long total)
 	{
 		this.total = total;
+	}
+
+
+	public List<String> getSql()
+	{
+		return sql;
+	}
+
+
+	public void setSql(final List<String> sql)
+	{
+		this.sql = sql;
 	}
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/DynamicQueryTest.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/DynamicQueryTest.java
@@ -19,11 +19,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(GuiceUnit.class)
-@GuiceConfig(config = "hibernate-tests-in-memory-hsqldb.properties",
-		classPackages = ParentEntity.class)
+@GuiceConfig(config = "hibernate-tests-in-memory-hsqldb.properties", classPackages = ParentEntity.class)
 public class DynamicQueryTest
 {
 	@Inject
@@ -194,13 +194,13 @@ public class DynamicQueryTest
 			dao.save(obj2);
 		}
 
-		assertEquals("deprecated=true matches 2 rows", 2, dao.findByUriQuery(new WebQuery().eq("deprecated", true))
-		                                                     .getList()
-		                                                     .size());
+		assertEquals("deprecated=true matches 2 rows",
+		             2,
+		             dao.findByUriQuery(new WebQuery().eq("deprecated", true)).getList().size());
 
-		assertEquals("deprecated=false matches nothing", 0, dao.findByUriQuery(new WebQuery().eq("deprecated", false))
-		                                                       .getList()
-		                                                       .size());
+		assertEquals("deprecated=false matches nothing",
+		             0,
+		             dao.findByUriQuery(new WebQuery().eq("deprecated", false)).getList().size());
 	}
 
 
@@ -216,6 +216,25 @@ public class DynamicQueryTest
 		dao.save(obj2);
 
 		assertEquals(getIds(Arrays.asList(obj1, obj2)), getIds(dao.findByUriQuery(new WebQuery().orderAsc("id")).getList()));
+	}
+
+
+	@Test
+	public void testLogSQL() throws Exception
+	{
+		ParentEntity obj1 = new ParentEntity();
+		obj1.setName("Name1");
+		dao.save(obj1);
+
+		ParentEntity obj2 = new ParentEntity();
+		obj2.setName("Name2");
+		dao.save(obj2);
+
+		final ConstrainedResultSet<ParentEntity> resultset = dao.findByUriQuery(new WebQuery().orderAsc("id").logSQL(true));
+
+		assertEquals(getIds(Arrays.asList(obj1, obj2)), getIds(resultset.getList())); // must have the right answer
+		assertNotNull(resultset.getSql());
+		assertTrue("Hibernate must have prepared at least one statement", resultset.getSql().size() >= 1);
 	}
 
 

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/WebappAuthenticationModule.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/WebappAuthenticationModule.java
@@ -67,6 +67,7 @@ public class WebappAuthenticationModule extends AbstractModule
 	@SessionScoped
 	public CurrentUser getCurrentUser(Injector injector, HttpServletRequest request)
 	{
+
 		for (String providerName : providerNames)
 		{
 			final Provider<CurrentUser> provider = injector.getProvider(Key.get(CurrentUser.class, Names.named(providerName)));


### PR DESCRIPTION
WebQuery now has an optional attribute, logSQL (defaults to false). If set to true then the resulting ConstrainedResultSet will have a List of SQL statements prepared by hibernate during the execution of that WebQuery. This allows for easier analysis of whether hibernate's producing sensible joins (if it's not this is probably an indicator that some relationship has been set up incorrectly with your annotations) and for easier acquisition of the SQL queries executed so that the right indexes can be constructed.

ConstrainedResultSet is an internal type, so a user would have to take action in order to make the logged queries available to users remotely - and in addition, the SQL logged is the prepared statement, containing ? placeholders for bound values (so only the database schema is being exposed - still a concern but much less than if application data was being returned - if a user-defined WebQuery is being executed then the user should already know a substantial amount about the data structure)