### PR TITLE
Replace JPA fetch annotations with own @EagerFetch annotation to work around long-standing Hibernate bug

### DIFF
--- a/guice/hibernate-testing/src/test/java/com/peterphi/std/guice/hibernatetest/SimpleEntity.java
+++ b/guice/hibernate-testing/src/test/java/com/peterphi/std/guice/hibernatetest/SimpleEntity.java
@@ -20,7 +20,7 @@ class SimpleEntity
 	@Column
 	public String name;
 
-	@ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToMany(cascade = CascadeType.ALL)
 	@JoinTable(name = "simple_entity_join_table",
 	           joinColumns = @JoinColumn(name = "simple_id", referencedColumnName = "id", nullable = false, updatable = false),
 	           inverseJoinColumns = @JoinColumn(name = "group_id",

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/database/annotation/EagerFetch.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/database/annotation/EagerFetch.java
@@ -1,0 +1,18 @@
+package com.peterphi.std.guice.database.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be placed on a member within a {@link javax.persistence.Entity}-annotated class to indicate that this should be
+ * eager-fetched when querying. This is a replacement for fetch=EAGER on the JPA annotations, because of <a href="https://hibernate.atlassian.net/browse/HHH-8776"></a>limitations in Hibernate
+ * since 2013</a> that prevent a FetchGraph from overriding fetch=EAGER annotated relations (which means that a user who only wants
+ * particular relations expanded must pay a time penalty for the EAGER-annotated relations to be retrieved too)
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EagerFetch
+{
+}

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/QEntity.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/QEntity.java
@@ -1,5 +1,6 @@
 package com.peterphi.std.guice.hibernate.webquery.impl;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 import com.peterphi.std.guice.restclient.jaxb.webqueryschema.WQEntitySchema;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -148,6 +149,7 @@ public class QEntity
 	 */
 	private void findReflectionIdFieldOrMethods()
 	{
+		// TODO replace with metamodelEntity OGNL? Could allow for easier customisation too
 		try
 		{
 			Field idField = null;
@@ -170,6 +172,7 @@ public class QEntity
 				}
 				else
 				{
+					// Annotation is on field, but field is not visible. We need to find the equivalent getter
 					final String getterName = "get" + idField.getName();
 					final String setterName = "set" + idField.getName();
 
@@ -249,18 +252,20 @@ public class QEntity
 	}
 
 
-	protected boolean isEagerFetch(Attribute<?, ?> attribute)
+	protected boolean isEagerFetch(final Attribute<?, ?> attribute)
 	{
 		if (attribute.isCollection() || attribute.isAssociation())
 		{
-			Member member = attribute.getJavaMember();
+			final Member member = attribute.getJavaMember();
 
 			if (member instanceof AnnotatedElement)
 			{
 				final AnnotatedElement el = (AnnotatedElement) member;
 
 				final FetchType fetchType;
-				if (el.isAnnotationPresent(OneToMany.class))
+				if (el.isAnnotationPresent(EagerFetch.class))
+					fetchType = FetchType.EAGER;
+				else if (el.isAnnotationPresent(OneToMany.class))
 					fetchType = el.getAnnotation(OneToMany.class).fetch();
 				else if (el.isAnnotationPresent(ManyToOne.class))
 					fetchType = el.getAnnotation(ManyToOne.class).fetch();

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilder.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilder.java
@@ -575,10 +575,7 @@ public class JPAQueryBuilder<T, ID> implements JPAQueryBuilderInternal
 	{
 		generated.select(root);
 
-		if (fetches != null)
-		{
-			addFetches(fetches);
-		}
+		applyFetches();
 
 		generated.orderBy(orders); // Make sure we return the results in the correct order
 
@@ -592,6 +589,14 @@ public class JPAQueryBuilder<T, ID> implements JPAQueryBuilderInternal
 		query.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
 
 		return query;
+	}
+
+
+	@Override
+	public void applyFetches()
+	{
+		if (fetches != null)
+			addFetches(fetches);
 	}
 
 

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilder.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilder.java
@@ -71,6 +71,7 @@ public class JPAQueryBuilder<T, ID> implements JPAQueryBuilderInternal
 		this.entity = entity;
 	}
 
+
 	void addFrom(final String subclasses)
 	{
 		if (StringUtils.isEmpty(subclasses))
@@ -596,6 +597,7 @@ public class JPAQueryBuilder<T, ID> implements JPAQueryBuilderInternal
 
 	/**
 	 * Returns true if one of the non-fetch joins specified will result in a collection being pulled back
+	 *
 	 * @return
 	 */
 	public boolean hasCollectionJoin()
@@ -608,7 +610,6 @@ public class JPAQueryBuilder<T, ID> implements JPAQueryBuilderInternal
 
 		return false;
 	}
-
 
 
 	/**

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilderInternal.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/JPAQueryBuilderInternal.java
@@ -12,13 +12,16 @@ public interface JPAQueryBuilderInternal
 {
 	/**
 	 * Add new Predicates which will be ANDed together with the top-level constraints specified in the WebQuery
+	 *
 	 * @param predicates
 	 * 		the predicate(s) to add
 	 */
 	void addConstraints(Predicate... predicates);
 
 	/**
-	 * Add new constraints as if they'd been defined at the top level of the WebQuery (N.B. will be ANDed together with all other constraints
+	 * Add new constraints as if they'd been defined at the top level of the WebQuery (N.B. will be ANDed together with all other
+	 * constraints
+	 *
 	 * @param constraints
 	 */
 	void addConstraints(List<WQConstraintLine> constraints);
@@ -40,4 +43,9 @@ public interface JPAQueryBuilderInternal
 	 * @return
 	 */
 	JPAJoin getOrCreateJoin(final WQPath path);
+
+	/**
+	 * Set up fetch joins as specified by the dbfetch/expand/default EAGER fetch annotations
+	 */
+	void applyFetches();
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdEmbeddedEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdEmbeddedEntity.java
@@ -1,0 +1,83 @@
+package com.peterphi.std.guice.hibernate.entitycollection;
+
+import com.google.common.base.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class AlternateIdEmbeddedEntity
+{
+	private String identifierSystem;
+	private String value;
+
+
+	public AlternateIdEmbeddedEntity()
+	{
+	}
+
+
+	public AlternateIdEmbeddedEntity(final String identifierSystem, final String value)
+	{
+		this.identifierSystem = identifierSystem;
+		this.value = value;
+	}
+
+
+	@Column(name = "id_system", nullable = false)
+	public String getIdentifierSystem()
+	{
+		return identifierSystem;
+	}
+
+
+	public void setIdentifierSystem(final String identifierSystem)
+	{
+		this.identifierSystem = identifierSystem;
+	}
+
+
+	@Column(name = "id_value", nullable = false)
+	public String getValue()
+	{
+		return value;
+	}
+
+
+	public void setValue(final String value)
+	{
+		this.value = value;
+	}
+
+
+	@Override
+	public boolean equals(final Object o)
+	{
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		AlternateIdEmbeddedEntity that = (AlternateIdEmbeddedEntity) o;
+
+		if (!identifierSystem.equals(that.identifierSystem))
+			return false;
+		return value.equals(that.value);
+	}
+
+
+	@Override
+	public int hashCode()
+	{
+		int result = identifierSystem.hashCode();
+		result = 31 * result + value.hashCode();
+		return result;
+	}
+
+
+	@Override
+	public String toString()
+	{
+		return Objects.toStringHelper(this).add("identifierSystem", identifierSystem).add("value", value).toString();
+	}
+}

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdReferencingEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdReferencingEntity.java
@@ -1,0 +1,47 @@
+package com.peterphi.std.guice.hibernate.entitycollection;
+
+import com.peterphi.std.guice.database.annotation.EagerFetch;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity(name = "refs_having_altid")
+public class AlternateIdReferencingEntity
+{
+	private Long id;
+	private HavingAlternateIdEntity referenced;
+
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	public Long getId()
+	{
+		return id;
+	}
+
+
+	public void setId(final Long id)
+	{
+		this.id = id;
+	}
+
+
+	@EagerFetch
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "referenced_id")
+	public HavingAlternateIdEntity getReferenced()
+	{
+		return referenced;
+	}
+
+
+	public void setReferenced(final HavingAlternateIdEntity referenced)
+	{
+		this.referenced = referenced;
+	}
+}

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ChildEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ChildEntity.java
@@ -1,6 +1,7 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
 import com.google.common.base.Objects;
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,8 +23,9 @@ class ChildEntity
 	@JoinColumn(nullable = false)
 	private ParentEntity parent;
 
-	@ManyToOne(optional = true, fetch = FetchType.EAGER)
-	@JoinColumn(nullable = true)
+	@EagerFetch
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn
 	private ParentEntity friend;
 
 	@Column(nullable = false)

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
@@ -244,6 +244,25 @@ public class EntityCollectionTest
 
 
 	@Test
+	public void testExpandOnlyPullsBackRequestedData() throws Exception
+	{
+		load();
+
+		{
+			final ConstrainedResultSet<ParentEntity> resultset = dao.find(new WebQuery()
+					                                                              .eq("children.flag", true)
+					                                                              .dbfetch("none")
+					                                                              .logSQL(true));
+
+			System.out.println("SQL: " + StringUtils.join(resultset.getSql(), "\n"));
+			System.out.println("SQL Statements: " + resultset.getSql().size());
+
+			assertEquals("Should only need 1 SQL statement", 1, resultset.getSql().size());
+		}
+	}
+
+
+	@Test
 	public void testLoadGraphWorksWithConstraintsAndLimit() throws Exception
 	{
 		load();

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
@@ -8,13 +8,16 @@ import com.peterphi.std.guice.restclient.jaxb.webquery.WebQuery;
 import com.peterphi.std.guice.testing.GuiceUnit;
 import com.peterphi.std.guice.testing.com.peterphi.std.guice.testing.annotations.GuiceConfig;
 import org.apache.commons.lang.StringUtils;
+import org.hibernate.Hibernate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(GuiceUnit.class)
 @GuiceConfig(config = "hibernate-tests-in-memory-hsqldb.properties", classPackages = ParentEntity.class)
@@ -318,8 +321,10 @@ public class EntityCollectionTest
 
 
 	@Transactional
-	public void load()
+	public List<Long> load()
 	{
+		List<Long> parentIds = new ArrayList<>();
+
 		{
 			ParentEntity p1 = new ParentEntity();
 			p1.setCapacity(2);
@@ -339,6 +344,8 @@ public class EntityCollectionTest
 			c3.setParent(p1);
 			c3.setFlag(false);
 			c3.setId(rDao.save(c3));
+
+			parentIds.add(p1.getId());
 		}
 
 
@@ -361,6 +368,45 @@ public class EntityCollectionTest
 			c3.setParent(p2);
 			c3.setFlag(false);
 			c3.setId(rDao.save(c3));
+
+			parentIds.add(p2.getId());
+		}
+
+		return parentIds;
+	}
+
+
+	@Test
+	public void testGetById() throws Exception
+	{
+		List<Long> ids = load();
+
+		final ParentEntity entity = dao.getById(ids.get(0));
+
+		assertTrue("Parent should be initialised", Hibernate.isInitialized(entity));
+		assertTrue("Parent.Children should be initialised", Hibernate.isInitialized(entity.getChildren()));
+		for (ChildEntity childEntity : entity.getChildren())
+		{
+			assertTrue("ChildEntity should be initialised", Hibernate.isInitialized(childEntity));
+		}
+	}
+
+
+	@Test
+	public void testGetListByIds() throws Exception
+	{
+		List<Long> ids = load();
+
+		final List<ParentEntity> entities = dao.getListById(ids);
+
+		for (ParentEntity entity : entities)
+		{
+			assertTrue("Parent should be initialised", Hibernate.isInitialized(entity));
+			assertTrue("Parent.Children should be initialised", Hibernate.isInitialized(entity.getChildren()));
+			for (ChildEntity childEntity : entity.getChildren())
+			{
+				assertTrue("ChildEntity should be initialised", Hibernate.isInitialized(childEntity));
+			}
 		}
 	}
 

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/EntityCollectionTest.java
@@ -29,6 +29,9 @@ public class EntityCollectionTest
 	@Inject
 	HibernateDao<ChildEntity, Long> rDao;
 
+	@Inject
+	HibernateDao<AlternateIdReferencingEntity, Long> altDao;
+
 
 	/**
 	 * Simple test that using HQL works
@@ -41,6 +44,13 @@ public class EntityCollectionTest
 		List<Long> ids = dao.getIdsByQuery("select q.id FROM parent_entity q");
 
 		assertEquals(0, ids.size());
+	}
+
+
+	@Test
+	public void testRetrieveEmbeddable()
+	{
+		altDao.getById(1L);
 	}
 
 

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/HavingAlternateIdEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/HavingAlternateIdEntity.java
@@ -1,0 +1,58 @@
+package com.peterphi.std.guice.hibernate.entitycollection;
+
+import com.google.common.base.Objects;
+import com.peterphi.std.guice.database.annotation.EagerFetch;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity(name = "having_altid")
+public class HavingAlternateIdEntity
+{
+	private Long id;
+	private Set<AlternateIdEmbeddedEntity> alternateIds = new HashSet<>();
+
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	public Long getId()
+	{
+		return id;
+	}
+
+
+	public void setId(final Long id)
+	{
+		this.id = id;
+	}
+
+
+	@EagerFetch
+	@ElementCollection(fetch = FetchType.LAZY)
+	@CollectionTable(name = "asset_alternate_id", joinColumns = @JoinColumn(name = "asset_id"))
+	public Set<AlternateIdEmbeddedEntity> getAlternateIds()
+	{
+		return alternateIds;
+	}
+
+
+	public void setAlternateIds(final Set<AlternateIdEmbeddedEntity> alternateIds)
+	{
+		this.alternateIds = alternateIds;
+	}
+
+
+	@Override
+	public String toString()
+	{
+		return Objects.toStringHelper(this).add("id", id).add("alternateIds", alternateIds).toString();
+	}
+}

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ParentEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ParentEntity.java
@@ -1,11 +1,11 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
 import com.google.common.base.Objects;
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -23,7 +23,8 @@ class ParentEntity
 	@Column(nullable = false)
 	private Integer capacity;
 
-	@OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
+	@EagerFetch
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "parent")
 	private Set<ChildEntity> children = new HashSet<>();
 
 

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/ChildEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/ChildEntity.java
@@ -1,5 +1,7 @@
 package com.peterphi.std.guice.hibernate.webquery;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -19,8 +21,9 @@ class ChildEntity
 	@Column(name = "obj_name")
 	private String name;
 
-	@ManyToOne(optional = true, fetch = FetchType.EAGER)
-	@JoinColumn(name = "parent_id", nullable = true)
+	@EagerFetch
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_id")
 	private ParentEntity parent;
 
 

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/ParentEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/webquery/ParentEntity.java
@@ -1,5 +1,7 @@
 package com.peterphi.std.guice.hibernate.webquery;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
+
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -32,14 +34,15 @@ public class ParentEntity
 	@Lob
 	private byte[] someBytes = "some bytes".getBytes();
 
-	@ManyToOne(optional = true, fetch = FetchType.LAZY)
-	@JoinColumn(name = "other_object_id", nullable = true)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "other_object_id")
 	private ChildEntity otherObject;
 
 	@OneToMany(mappedBy = "parent")
 	private Set<ChildEntity> children;
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@EagerFetch
+	@ElementCollection
 	@CollectionTable(name = "parent_friends", joinColumns = @JoinColumn(name = "parent_id"))
 	private Set<HumanEmbeddedEntity> friends = new HashSet<>();
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<metrics.version>3.0.2</metrics.version>
 		<resteasy.version>3.0.19.Final</resteasy.version>
 		<javassist.version>3.19.0-GA</javassist.version>
-		<hibernate.version>5.2.10.Final</hibernate.version>
+		<hibernate.version>5.2.11.Final</hibernate.version>
 		<dbunit.version>2.5.1</dbunit.version>
 		<hsqldb.version>2.3.2</hsqldb.version>
 		<bouncycastle.version>1.55</bouncycastle.version>

--- a/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/db/entity/ResourceInstanceEntity.java
+++ b/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/db/entity/ResourceInstanceEntity.java
@@ -1,11 +1,13 @@
 package com.peterphi.servicemanager.service.db.entity;
 
 import com.peterphi.servicemanager.service.rest.resource.type.ResourceInstanceState;
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 import org.joda.time.DateTime;
 
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -44,8 +46,9 @@ public class ResourceInstanceEntity
 	}
 
 
+	@EagerFetch
 	@JoinColumn(name = "template_id", nullable = false)
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	public ResourceTemplateEntity getTemplate()
 	{
 		return template;
@@ -87,6 +90,7 @@ public class ResourceInstanceEntity
 	}
 
 
+	@EagerFetch
 	@ElementCollection
 	@JoinTable(name = "resource_instance_metadata", joinColumns = @JoinColumn(name = "resource_instance_id"))
 	@MapKeyColumn(name = "meta_name")

--- a/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/db/entity/ResourceTemplateEntity.java
+++ b/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/db/entity/ResourceTemplateEntity.java
@@ -48,7 +48,7 @@ public class ResourceTemplateEntity
 	}
 
 
-	@OneToMany(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@OneToMany(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true)
 	@OrderBy("state")
 	public List<ResourceInstanceEntity> getInstances()
 	{

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthServiceEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthServiceEntity.java
@@ -1,5 +1,6 @@
 package com.peterphi.usermanager.db.entity;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 import com.peterphi.std.types.SimpleId;
 import org.joda.time.DateTime;
 
@@ -34,7 +35,8 @@ public class OAuthServiceEntity
 	}
 
 
-	@ManyToOne(optional = false, fetch = FetchType.EAGER)
+	@EagerFetch
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id", nullable = false)
 	public UserEntity getOwner()
 	{

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthSessionContextEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthSessionContextEntity.java
@@ -1,5 +1,6 @@
 package com.peterphi.usermanager.db.entity;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 import org.joda.time.DateTime;
 
 import javax.persistence.Column;
@@ -34,7 +35,8 @@ public class OAuthSessionContextEntity
 	}
 
 
-	@ManyToOne(optional = false, fetch = FetchType.EAGER)
+	@EagerFetch
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	public UserEntity getUser()
 	{
@@ -42,7 +44,8 @@ public class OAuthSessionContextEntity
 	}
 
 
-	@ManyToOne(optional = false, fetch = FetchType.EAGER)
+	@EagerFetch
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "service_id", nullable = false)
 	public OAuthServiceEntity getService()
 	{

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthSessionEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/OAuthSessionEntity.java
@@ -1,5 +1,6 @@
 package com.peterphi.usermanager.db.entity;
 
+import com.peterphi.std.guice.database.annotation.EagerFetch;
 import org.joda.time.DateTime;
 
 import javax.persistence.Column;
@@ -39,7 +40,8 @@ public class OAuthSessionEntity
 	}
 
 
-	@ManyToOne(optional = false, fetch = FetchType.EAGER)
+	@EagerFetch
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "context_id", nullable = false)
 	public OAuthSessionContextEntity getContext()
 	{

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/RoleEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/RoleEntity.java
@@ -52,7 +52,7 @@ public class RoleEntity
 
 
 	@OrderBy("id DESC")
-	@ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToMany(cascade = CascadeType.ALL)
 	@JoinTable(name = "user_has_role", //
 			joinColumns = {@JoinColumn(name = "role_id", referencedColumnName = "id", nullable = false, updatable = false)}, inverseJoinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, updatable = false)}, uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id",
 			                                                                                                                                                                                                                                                                                               "role_id"})})

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/UserEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/UserEntity.java
@@ -188,7 +188,7 @@ public class UserEntity
 	}
 
 
-	@ManyToMany(fetch = FetchType.LAZY, mappedBy = "members")
+	@ManyToMany(mappedBy = "members")
 	public List<RoleEntity> getRoles()
 	{
 		return roles;


### PR DESCRIPTION
Hibernate does not comply with the JPA specification for the FetchGraph query hint (see 
https://hibernate.atlassian.net/browse/HHH-8776 - open since 2013 with no intention to fix).

This PR introduces a new annotation ```@EagerFetch``` which should be used instead of JPA annotation param ```fetch = FetchType.EAGER```  (in fact, it should be used with explicit ```fetch = FetchType.LAZY``` so that hibernate only fetches what the user asks it to fetch every time).

This commit includes code that builds a dynamic EntityGraph based on ```@EagerFetch``` (and on JPA annotations with fetch=EAGER for backwards-compatibility) to maintain the old behaviour while allowing user queries (whether remote or local) to explicitly request that ```@EagerFetch``` relations not be brought back as part of the initial SQL - this allows them to more finely control the size of their queries and the resulting performance.