### PR TITLE
Update to resteasy 3.1.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<guice.version>3.2.6</guice.version>
 <!--		<guice.version>4.1.0</guice.version> -->
 		<metrics.version>3.0.2</metrics.version>
-		<resteasy.version>3.0.19.Final</resteasy.version>
+		<resteasy.version>3.1.4.Final</resteasy.version>
 		<javassist.version>3.19.0-GA</javassist.version>
 		<hibernate.version>5.2.11.Final</hibernate.version>
 		<dbunit.version>2.5.1</dbunit.version>


### PR DESCRIPTION
Primarily so that  so that the jboss-logging dependency is at 3.3.0.Final consistently across resteasy and hibernate