### PR TITLE
Fix and improve drop-frame timecode support, introduce support (and t…

### DIFF
--- a/stdlib/src/test/java/com/peterphi/std/types/TimebaseTest.java
+++ b/stdlib/src/test/java/com/peterphi/std/types/TimebaseTest.java
@@ -43,6 +43,23 @@ public class TimebaseTest
 	}
 
 
+	/**
+	 * A frame of NTSC is longer than a frame of 30Hz video (since there are only 29.97 frames of NTSC a second). Over an hour this gives us 108 fewer frames.<br />
+	 * Make sure that resampling
+	 * @throws Exception
+	 */
+	@Test
+	public void testResampleDropFrame() throws Exception
+	{
+		final double delta = 0;
+
+		assertEquals("1 hour @ 30fps (108000 frames) is the same duration as 107892 frames @ 29.97",
+		             107892D,
+		             Timebase.NTSC.resample(108000, Timebase.HZ_30),
+		             delta);
+		assertEquals("1 hour @ 29.97fps (107892 frames) is 108000 frames in 30fps", 108000D, Timebase.HZ_30.resample(107892, Timebase.NTSC), delta);
+	}
+
 	@Test
 	public void testResample() throws Exception
 	{


### PR DESCRIPTION
 - Fix and improve drop-frame timecode support. When resampling it is now possible to specify whether you want drop-frame timecode output.
 - Introduce support (and tests) for 24p (23.976) which doesn't use drop-frame timecode.
 - By default, don't log a warning when a Timecode resample loses precision (since this just results in spamming logs)