### PR TITLE
Add API Tokens for users

### DIFF
--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/UserManagerAccessKeyToSessionCache.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/UserManagerAccessKeyToSessionCache.java
@@ -43,7 +43,7 @@ public class UserManagerAccessKeyToSessionCache
 		}
 		catch (ExecutionException e)
 		{
-			throw new RuntimeException("Error allocating session for bearer token", e);
+			throw new RuntimeException("Error allocating session for bearer token", (e.getCause() != null) ? e.getCause() : e);
 		}
 	}
 

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/UserManagerAccessKeyToSessionCache.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/UserManagerAccessKeyToSessionCache.java
@@ -1,0 +1,65 @@
+package com.peterphi.std.guice.web.rest.auth.oauth2;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.peterphi.usermanager.util.UserManagerBearerToken;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Turns a User Manager Bearer Token to an OAuth2SessionRef, populating the Session scope with that OAuth2SessionRef.<br />
+ */
+@Singleton
+public class UserManagerAccessKeyToSessionCache
+{
+	@Inject
+	public Provider<OAuth2SessionRef> sessionRefProvider;
+
+	private final Cache<String, OAuth2SessionRef> bearerToSessionRefCache = CacheBuilder
+			                                                                        .newBuilder()
+			                                                                        .expireAfterAccess(20, TimeUnit.MINUTES)
+			                                                                        .maximumSize(1024)
+			                                                                        .build();
+
+
+	public OAuth2SessionRef getOrCreateSessionRef(final String token)
+	{
+		if (!UserManagerBearerToken.isUserManagerBearer(token))
+			return null; // Not a user manager bearer token
+
+		try
+		{
+			OAuth2SessionRef ref = bearerToSessionRefCache.get(token, () -> initialiseSessionRef(token));
+
+			// If the back-end session is invalid or has expired then re-initialise it with the token
+			if (!ref.isValid())
+				ref.initialiseFromAPIToken(token);
+
+			return ref;
+		}
+		catch (ExecutionException e)
+		{
+			throw new RuntimeException("Error allocating session for bearer token", e);
+		}
+	}
+
+
+	/**
+	 * @param token
+	 *
+	 * @return
+	 */
+	OAuth2SessionRef initialiseSessionRef(final String token)
+	{
+		final OAuth2SessionRef session = sessionRefProvider.get();
+
+		if (!session.hasBeenInitialised())
+			session.initialiseFromAPIToken(token);
+
+		return session;
+	}
+}

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/rest/impl/OAuth2ClientCallbackRestServiceImpl.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/oauth2/rest/impl/OAuth2ClientCallbackRestServiceImpl.java
@@ -64,11 +64,12 @@ public class OAuth2ClientCallbackRestServiceImpl implements OAuth2ClientCallback
 
 
 		// Now call to exchange the authorisation code for a token
-		final String responseStr = remote.getToken("authorization_code",
+		final String responseStr = remote.getToken(UserManagerOAuthService.GRANT_TYPE_AUTHORIZATION_CODE,
 		                                           code,
 		                                           sessionRef.getOwnCallbackUri().toString(),
 		                                           clientId,
 		                                           clientSecret,
+		                                           null,
 		                                           null,
 		                                           null,
 		                                           null);

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallJWTUser.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallJWTUser.java
@@ -8,6 +8,7 @@ import com.peterphi.std.guice.common.auth.iface.AccessRefuser;
 import com.peterphi.std.guice.common.auth.iface.CurrentUser;
 import com.peterphi.std.guice.restclient.exception.RestException;
 import com.peterphi.std.guice.web.HttpCallContext;
+import com.peterphi.usermanager.util.UserManagerBearerToken;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.jboss.resteasy.util.HttpHeaderNames;
@@ -222,7 +223,8 @@ class HttpCallJWTUser implements CurrentUser
 				else
 					return null;
 			}
-			else if (StringUtils.startsWithIgnoreCase(header, "Bearer"))
+			else if (StringUtils.startsWithIgnoreCase(header, "Bearer") &&
+			         !UserManagerBearerToken.isUserManagerBearerAuthorizationHeader(header))
 			{
 				// Bearer token
 				return header.substring("Bearer".length() + 1);

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/scoping/SessionScoping.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/scoping/SessionScoping.java
@@ -2,15 +2,15 @@ package com.peterphi.std.guice.web.rest.scoping;
 
 /**
  * Based on Guice ServletScopes<br />
- *
+ * <p>
  * Copyright (C) 2006 Google Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,7 @@ import com.peterphi.std.guice.web.HttpCallContext;
 
 import javax.servlet.http.HttpSession;
 
-final class SessionScoping implements Scope
+public final class SessionScoping implements Scope
 {
 	public static final SessionScoping INSTANCE = new SessionScoping();
 
@@ -39,9 +39,11 @@ final class SessionScoping implements Scope
 		INSTANCE
 	}
 
+
 	private SessionScoping()
 	{
 	}
+
 
 	public <T> Provider<T> scope(Key<T> key, final Provider<T> creator)
 	{
@@ -85,6 +87,7 @@ final class SessionScoping implements Scope
 				}
 			}
 
+
 			@Override
 			public String toString()
 			{
@@ -92,6 +95,45 @@ final class SessionScoping implements Scope
 			}
 		};
 	}
+
+
+	public <T> void seed(Key<T> key, T instance)
+	{
+		final String name = key.toString();
+
+		final HttpCallContext ctx = HttpCallContext.get();
+		final HttpSession session = ctx.getRequest().getSession();
+
+		synchronized (session)
+		{
+			if (exists(key))
+				throw new IllegalArgumentException("Cannot seed Session scope with instance for " +
+				                                   key +
+				                                   ": Session scope already has an instance of this key!");
+
+			if (instance != null)
+				session.setAttribute(name, instance);
+			else
+				session.setAttribute(name, NullObject.INSTANCE);
+		}
+	}
+
+
+	public <T> boolean exists(Key<T> key)
+	{
+		final String name = key.toString();
+
+		final HttpCallContext ctx = HttpCallContext.get();
+		final HttpSession session = ctx.getRequest().getSession();
+
+		synchronized (session)
+		{
+			final Object obj = session.getAttribute(name);
+
+			return (obj == null || obj == NullObject.INSTANCE);
+		}
+	}
+
 
 	@Override
 	public String toString()

--- a/user-manager/api/src/main/java/com/peterphi/usermanager/rest/iface/oauth2server/UserManagerOAuthService.java
+++ b/user-manager/api/src/main/java/com/peterphi/usermanager/rest/iface/oauth2server/UserManagerOAuthService.java
@@ -17,6 +17,13 @@ import javax.ws.rs.core.Response;
 @Doc("Implements the OAuth2 flow")
 public interface UserManagerOAuthService
 {
+	String GRANT_TYPE_AUTHORIZATION_CODE="authorization_code";
+	String GRANT_TYPE_REFRESH_TOKEN="refresh_token";
+	String GRANT_TYPE_TOKEN_EXCHANGE="urn:ietf:params:oauth:grant-type:token-exchange";
+	String GRANT_TYPE_PASSWORD = "password";
+	String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+
+
 	@GET
 	@Path("/authorize")
 	Response getAuth(@QueryParam("response_type") @Doc("The response type - N.B. only code supported") String responseType,
@@ -55,7 +62,7 @@ public interface UserManagerOAuthService
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces({MediaType.APPLICATION_JSON})
 	public String getToken(@FormParam("grant_type")
-	                       @Doc("One of: authorization_code,refresh_token,password,client_credentials (HTTP BASIC)")
+	                       @Doc("One of: authorization_code,refresh_token,urn:ietf:params:oauth:grant-type:token-exchange,password,client_credentials")
 			                       String grantType, @FormParam("code")
 	                       @Doc("The authorization code from the auth callback (where grant_type is authorization_code)")
 			                       String code,
@@ -65,7 +72,8 @@ public interface UserManagerOAuthService
 	                       @FormParam("refresh_token") @Doc("The refresh token (where grant_type is refresh_token)")
 			                       String refreshToken,
 	                       @FormParam("username") @Doc("The username (where grant_type is password)") String username,
-	                       @FormParam("password") @Doc("The password (where grant_type is password)") String password);
+	                       @FormParam("password") @Doc("The password (where grant_type is password)") String password,
+	                       @FormParam("subject_token") @Doc("The subject_token (where grant_type is urn:ietf:params:oauth:grant-type:token-exchange)") String subjectToken);
 
 
 	/**

--- a/user-manager/api/src/main/java/com/peterphi/usermanager/util/UserManagerBearerToken.java
+++ b/user-manager/api/src/main/java/com/peterphi/usermanager/util/UserManagerBearerToken.java
@@ -1,0 +1,28 @@
+package com.peterphi.usermanager.util;
+
+public final class UserManagerBearerToken
+{
+	public static final String PREFIX = "UMB/";
+	private static final String HTTP_AUTHORIZATION_HEADER_BEARER_CONST = "Bearer ";
+	private static final String HTTP_AUTHORIZATION_HEADER_PREFIX = HTTP_AUTHORIZATION_HEADER_BEARER_CONST + PREFIX;
+
+
+	public static boolean isUserManagerBearer(final String token)
+	{
+		return token.startsWith(PREFIX);
+	}
+
+
+	public static boolean isUserManagerBearerAuthorizationHeader(final String header)
+	{
+		return header != null && header.startsWith(HTTP_AUTHORIZATION_HEADER_PREFIX);
+	}
+
+
+	public static String getTokenFromBearerAuthorizationHeader(final String header)
+	{
+		assert (isUserManagerBearerAuthorizationHeader(header));
+
+		return header.substring(HTTP_AUTHORIZATION_HEADER_BEARER_CONST.length());
+	}
+}

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/UserEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/UserEntity.java
@@ -34,6 +34,16 @@ public class UserEntity
 	private String password;
 
 	/**
+	 * The primary access key (the key all API clients should use for this account). Optional.
+	 */
+	private String accessKey;
+
+	/**
+	 * The secondary access key (allows keys to be rotated out without a big-bang reconfiguration of API users). Optional.
+	 */
+	private String accessKeySecondary;
+
+	/**
 	 * The user's desired date format
 	 */
 	private String dateFormat;
@@ -118,6 +128,42 @@ public class UserEntity
 	public void setPassword(String password)
 	{
 		this.password = password;
+	}
+
+
+	/**
+	 * Access key, allows API clients more easy use of a User Manager User.
+	 *
+	 * @return
+	 */
+	@Column(name = "access_key", nullable = true, length = 100)
+	public String getAccessKey()
+	{
+		return accessKey;
+	}
+
+
+	public void setAccessKey(final String accessKey)
+	{
+		this.accessKey = accessKey;
+	}
+
+
+	/**
+	 * Access key, allows API clients more easy use of a User Manager User.
+	 *
+	 * @return
+	 */
+	@Column(name = "access_key_alt", nullable = true, length = 100)
+	public String getAccessKeySecondary()
+	{
+		return accessKeySecondary;
+	}
+
+
+	public void setAccessKeySecondary(final String accessKeySecondary)
+	{
+		this.accessKeySecondary = accessKeySecondary;
 	}
 
 

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/ui/api/UserUIService.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/ui/api/UserUIService.java
@@ -45,6 +45,11 @@ public interface UserUIService
 	                         @FormParam("roles") List<String> roles);
 
 	@POST
+	@Path("/user/{user_id}/rotate-access-key")
+	@Produces(MediaType.TEXT_HTML)
+	Response rotateAccessKey(@PathParam("user_id") int userId, @FormParam("nonce") String nonce);
+
+	@POST
 	@Path("/user/{user_id}/delete")
 	@Produces(MediaType.TEXT_HTML)
 	Response deleteUser(@PathParam("user_id") int userId, @FormParam("nonce") String nonce);

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/ui/impl/UserUIServiceImpl.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/ui/impl/UserUIServiceImpl.java
@@ -175,6 +175,23 @@ public class UserUIServiceImpl implements UserUIService
 
 
 	@Override
+	public Response rotateAccessKey(final int userId, final String nonce)
+	{
+		nonceStore.validate(NONCE_USE, nonce);
+
+		final int localUser = login.getId();
+
+		if (localUser != userId && !login.isAdmin())
+			throw new AuthenticationFailureException("Only a User Admin can rotate access keys another user!");
+
+		// Change regular account settings
+		accountDao.rotateUserAccessKey(userId);
+
+		return Response.seeOther(URI.create("/user/" + userId)).build();
+	}
+
+
+	@Override
 	@Transactional
 	@AuthConstraint(role = UserLogin.ROLE_ADMIN)
 	public Response deleteUser(final int userId, final String nonce)

--- a/user-manager/service/src/main/resources/liquibase/000-Original.xml
+++ b/user-manager/service/src/main/resources/liquibase/000-Original.xml
@@ -254,4 +254,12 @@
 			</column>
 		</addColumn>
 	</changeSet>
+
+
+	<changeSet author="peter@peterphi.com" id="add_user_access_key">
+		<addColumn tableName="user_account">
+			<column name="access_key" type="VARCHAR(100)" />
+			<column name="access_key_alt" type="VARCHAR(100)" />
+		</addColumn>
+	</changeSet>
 </databaseChangeLog>

--- a/user-manager/service/src/main/resources/service.properties
+++ b/user-manager/service/src/main/resources/service.properties
@@ -47,3 +47,11 @@ authentication-backend=internal
 #ldap.group.admin=
 #ldap.group.framework-admin=
 #ldap.group.framework-info=
+
+
+# By default, be permissive with how users can use their Access Keys: allow them to access all services
+auth.access-key.create-new-session-context-if-necessary=true
+# By default, interactive users must approve new session context (i.e. approve each service they want to access)
+#auth.interactive.create-new-session-context-if-necessary=false
+# If set to true, this would allow all accesses to implicitly create a new session context without interactive approval if needed
+#auth.all.create-new-session-context-if-necessary=false

--- a/user-manager/service/src/main/webapp/WEB-INF/template/user_edit.html
+++ b/user-manager/service/src/main/webapp/WEB-INF/template/user_edit.html
@@ -18,6 +18,7 @@
 			Password</a></li>
 		<li th:if="${session.login.isAdmin()}"><a href="#deluserModal" data-toggle="modal">Delete User</a></li>
 		<li th:if="${session.login.isAdmin()}"><a href="#impersonateModal" data-toggle="modal">Impersonate</a></li>
+		<li th:if="${session.login.isAdmin() or (session.login.getId() == user.id)}"><a href="#rotateKeyModal" data-toggle="modal"><span th:text="${user.accessKey != null ? 'Rotate' : 'Assign'}">Rotate</span> API Key</a></li>
 	</ul>
 
 	<!-- Change password modal -->
@@ -108,6 +109,27 @@
 				<input class="btn btn-primary" type="submit" value="Impersonate"/>
 			</div>
 		</form>
+
+
+		<!-- Rotate API keys modal -->
+		<form id="rotateKeyModal" class="modal hide fade form-horizontal" tabindex="-1" role="dialog"
+		      aria-labelledby="rotateKeyModalLabel" aria-hidden="true" method="POST" autocomplete="off"
+		      th:action="@{'/user/' + ${user.id} + '/rotate-access-key'}">
+			<div class="modal-header">
+				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+				<h3 id="rotateKeyModalLabel"><span th:text="${user.accessKey != null ? 'Rotate' : 'Assign'}">Rotate</span> API Key</h3>
+			</div>
+			<div class="modal-body">
+				<p>Assign a new API key for this user? If an Access Key is already assigned then a new key will be assigned and the old key will be moved to the Access Key Secondary field (and will continue to work until a subsequent rotation or until that key is revoked). Are you sure?</p>
+				<input type="hidden" name="alter" value="rotateKey"/>
+				<input type="hidden" name="id" th:value="${user.id}"/>
+				<input type="hidden" name="nonce" th:value="${nonce}"/>
+			</div>
+			<div class="modal-footer">
+				<button class="btn" data-dismiss="modal" aria-hidden="true">Cancel</button>
+				<input class="btn btn-primary" type="submit" value="Rotate"/>
+			</div>
+		</form>
 	</th:block>
 
 	<form class="form-horizontal" method="POST">
@@ -124,7 +146,7 @@
 		</div>
 
 		<!-- isLocal -->
-		<div class="control-group">
+		<div class="control-group" th:if="${session.login.isAdmin()}">
 			<label class="control-label" for="view_lastLogin">local user</label>
 
 			<div class="controls">
@@ -237,6 +259,22 @@
 					$(".chosen-select").chosen({});
 				});
 			</script>
+		</div>
+
+		<div class="control-group" th:if="${(session.login.getId() == user.id) and user.accessKey}">
+			<label class="control-label" for="view_AccessKey">API Access Key</label>
+
+			<div class="controls">
+				<input type="text" onClick="this.select(); document.execCommand('Copy');" readonly="readonly" id="view_AccessKey" th:value="${user.accessKey}" alt="Click to copy" title="Click to copy"/><br />
+			</div>
+		</div>
+
+		<div class="control-group" th:if="${(session.login.getId() == user.id) and user.accessKeySecondary}">
+			<label class="control-label" for="view_SecondaryAccessKey">API Access Key (Secondary)</label>
+
+			<div class="controls">
+				<input type="text" onClick="this.select(); document.execCommand('Copy');" readonly="readonly" id="view_SecondaryAccessKey" th:value="${user.accessKeySecondary}" alt="Click to copy" title="Click to copy"/>
+			</div>
 		</div>
 
 


### PR DESCRIPTION
Gives users API Tokens (each user can have up to 2, user is able to rotate keys which generates new key -> primary -> secondary).

API key is used by supplying "Authorization: Bearer" header,  using API key provided from the UI (N.B. access keys have a well-known prefix so that we can distinguish between JWTs and User Manager tokens)