### PR TITLE
Library Version Upgrade for Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
   - rm -f $HOME/.m2/repository/com/peterphi
   
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
   - rm -f $HOME/.m2/repository/com/peterphi
   
 jdk:
-  - oraclejdk9
+  - oraclejdk10
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
   - rm -f $HOME/.m2/repository/com/peterphi
   
 jdk:
-  - oraclejdk10
+  - oraclejdk9
 
 env:
   global:

--- a/guice/common/src/main/java/com/peterphi/std/guice/common/auth/AuthScope.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/common/auth/AuthScope.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.common.auth;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.common.auth.annotations.AuthConstraint;
 
 public class AuthScope
@@ -43,6 +43,6 @@ public class AuthScope
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("name", name).add("role", role).add("skip", skip).toString();
+		return MoreObjects.toStringHelper(this).add("name", name).add("role", role).add("skip", skip).toString();
 	}
 }

--- a/guice/common/src/main/java/com/peterphi/std/guice/common/serviceprops/net/NetworkConfig.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/common/serviceprops/net/NetworkConfig.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.common.serviceprops.net;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.peterphi.std.guice.apploader.GuiceProperties;
@@ -68,7 +68,7 @@ public class NetworkConfig
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("path", path).add("initialRevision", initialRevision).add("properties",
+		return MoreObjects.toStringHelper(this).add("path", path).add("initialRevision", initialRevision).add("properties",
 		                                                                                                  properties).add(
 				"lastLoadedRevision",
 				lastLoadedRevision).toString();

--- a/guice/common/src/main/java/com/peterphi/std/guice/config/rest/types/ConfigPropertyData.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/config/rest/types/ConfigPropertyData.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.config.rest.types;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -26,11 +26,11 @@ public class ConfigPropertyData
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this)
-		              .add("path", path)
-		              .add("revision", revision)
-		              .add("timestamp", timestamp)
-		              .add("properties", properties)
-		              .toString();
+		return MoreObjects.toStringHelper(this)
+		                  .add("path", path)
+		                  .add("revision", revision)
+		                  .add("timestamp", timestamp)
+		                  .add("properties", properties)
+		                  .toString();
 	}
 }

--- a/guice/common/src/main/java/com/peterphi/std/guice/config/rest/types/ConfigPropertyValue.java
+++ b/guice/common/src/main/java/com/peterphi/std/guice/config/rest/types/ConfigPropertyValue.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.config.rest.types;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
@@ -55,11 +55,11 @@ public class ConfigPropertyValue
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this)
-		              .omitNullValues()
-		              .add("path", path)
-		              .add("name", name)
-		              .add("value", value)
-		              .toString();
+		return MoreObjects.toStringHelper(this)
+		                  .omitNullValues()
+		                  .add("path", path)
+		                  .add("name", name)
+		                  .add("value", value)
+		                  .toString();
 	}
 }

--- a/guice/common/src/test/java/com/peterphi/std/guice/common/serviceprops/jaxbref/MyType.java
+++ b/guice/common/src/test/java/com/peterphi/std/guice/common/serviceprops/jaxbref/MyType.java
@@ -1,7 +1,7 @@
 package com.peterphi.std.guice.common.serviceprops.jaxbref;
 
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.common.lifecycle.GuiceLifecycleListener;
 
 import javax.xml.bind.annotation.XmlAttribute;
@@ -55,7 +55,7 @@ class MyType implements GuiceLifecycleListener
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("name", name).add("postConstructCalled", postConstructCalled).toString();
+		return MoreObjects.toStringHelper(this).add("name", name).add("postConstructCalled", postConstructCalled).toString();
 	}
 
 

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/QRelation.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/QRelation.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.webquery.impl;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.restclient.jaxb.webqueryschema.WQDataType;
 import com.peterphi.std.guice.restclient.jaxb.webqueryschema.WQEntityProperty;
 
@@ -95,7 +95,7 @@ public class QRelation
 	@Override
 	public String toString()
 	{
-		return Objects
+		return MoreObjects
 				       .toStringHelper(this)
 				       .add("owner", owner)
 				       .add("name", name)

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/jpafunctions/WQPath.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/jpafunctions/WQPath.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.webquery.impl.jpa.jpafunctions;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class WQPath
 {
@@ -67,6 +67,6 @@ public class WQPath
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("path", path).toString();
+		return MoreObjects.toStringHelper(this).add("path", path).toString();
 	}
 }

--- a/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/jpafunctions/WQPathSegment.java
+++ b/guice/hibernate/src/main/java/com/peterphi/std/guice/hibernate/webquery/impl/jpa/jpafunctions/WQPathSegment.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.webquery.impl.jpa.jpafunctions;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class WQPathSegment
 {
@@ -38,6 +38,6 @@ public class WQPathSegment
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("segment", segment).toString();
+		return MoreObjects.toStringHelper(this).add("segment", segment).toString();
 	}
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdEmbeddedEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/AlternateIdEmbeddedEntity.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -78,6 +78,6 @@ public class AlternateIdEmbeddedEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("identifierSystem", identifierSystem).add("value", value).toString();
+		return MoreObjects.toStringHelper(this).add("identifierSystem", identifierSystem).add("value", value).toString();
 	}
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ChildEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ChildEntity.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.database.annotation.EagerFetch;
 
 import javax.persistence.Column;
@@ -83,6 +83,6 @@ class ChildEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("id", id).toString();
+		return MoreObjects.toStringHelper(this).add("id", id).toString();
 	}
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/HavingAlternateIdEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/HavingAlternateIdEntity.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.database.annotation.EagerFetch;
 
 import javax.persistence.CollectionTable;
@@ -53,6 +53,6 @@ public class HavingAlternateIdEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("id", id).add("alternateIds", alternateIds).toString();
+		return MoreObjects.toStringHelper(this).add("id", id).add("alternateIds", alternateIds).toString();
 	}
 }

--- a/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ParentEntity.java
+++ b/guice/hibernate/src/test/java/com/peterphi/std/guice/hibernate/entitycollection/ParentEntity.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.hibernate.entitycollection;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.database.annotation.EagerFetch;
 
 import javax.persistence.CascadeType;
@@ -67,6 +67,6 @@ class ParentEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("id", id).toString();
+		return MoreObjects.toStringHelper(this).add("id", id).toString();
 	}
 }

--- a/guice/liquibase/pom.xml
+++ b/guice/liquibase/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
-			<version>3.5.3</version>
+			<version>3.5.5</version>
 		</dependency>
 
 

--- a/guice/liquibase/src/main/java/com/peterphi/std/guice/liquibase/hibernate/LiquibaseCore.java
+++ b/guice/liquibase/src/main/java/com/peterphi/std/guice/liquibase/hibernate/LiquibaseCore.java
@@ -20,7 +20,6 @@ import liquibase.exception.LiquibaseException;
 import liquibase.logging.LogFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.CompositeResourceAccessor;
-import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -188,9 +187,8 @@ class LiquibaseCore
 					ResourceAccessor threadClFO = new ClassLoaderResourceAccessor(contextClassLoader);
 
 					ResourceAccessor clFO = new ClassLoaderResourceAccessor();
-					ResourceAccessor fsFO = new FileSystemResourceAccessor();
 
-					composite = new CompositeResourceAccessor(clFO, fsFO, threadClFO);
+					composite = new CompositeResourceAccessor(clFO, threadClFO);
 				}
 
 				// If loading a resource with an absolute path fails, re-try it as a path relative to /

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -69,5 +69,6 @@
 		<module>hibernate-testing</module>
 		<module>liquibase</module>
 		<module>testing</module>
+		<module>xml-testing</module>
 	</modules>
 </project>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -34,7 +34,6 @@
 		</dependency>
 
 		<!-- guice -->
-		<!-- official guice 
 		<dependency>
 		  <groupId>com.google.inject</groupId>
 		  <artifactId>guice</artifactId>
@@ -46,18 +45,6 @@
 		  <artifactId>guice-multibindings</artifactId>
 			<version>${guice.version}</version>
 		</dependency>
-		-->
-		
-		<dependency>
-			<groupId>org.sonatype.sisu</groupId>
-			<artifactId>sisu-guice</artifactId>
-			<version>${guice.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.sonatype.sisu.inject</groupId>
-			<artifactId>guice-multibindings</artifactId>
-			<version>${guice.version}</version>
-		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.xbean</groupId>
@@ -67,8 +54,8 @@
 
 		<dependency>
 			<groupId>org.ow2.asm</groupId>
-			<artifactId>asm-all</artifactId>
-			<version>5.0.4</version>
+			<artifactId>asm</artifactId>
+			<version>6.1</version>
 		</dependency>
 
 	</dependencies>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.apache.xbean</groupId>
 			<artifactId>xbean-finder</artifactId>
-			<version>4.4</version>
+			<version>4.7</version>
 		</dependency>
 
 		<dependency>

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallJWTUser.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallJWTUser.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.web.rest.auth.userprovider;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.peterphi.std.guice.apploader.GuiceConstants;
@@ -342,6 +342,6 @@ class HttpCallJWTUser implements CurrentUser
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("claims", get()).toString();
+		return MoreObjects.toStringHelper(this).add("claims", get()).toString();
 	}
 }

--- a/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallUser.java
+++ b/guice/webapp/src/main/java/com/peterphi/std/guice/web/rest/auth/userprovider/HttpCallUser.java
@@ -1,6 +1,6 @@
 package com.peterphi.std.guice.web.rest.auth.userprovider;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.peterphi.std.guice.apploader.GuiceConstants;
 import com.peterphi.std.guice.common.auth.iface.AccessRefuser;
 import com.peterphi.std.guice.common.auth.iface.CurrentUser;
@@ -108,6 +108,6 @@ class HttpCallUser implements CurrentUser
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("principal", getName()).toString();
+		return MoreObjects.toStringHelper(this).add("principal", getName()).toString();
 	}
 }

--- a/guice/xml-testing/pom.xml
+++ b/guice/xml-testing/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.peterphi.std.guice</groupId>
+	<artifactId>stdlib-xml-testing</artifactId>
+	<version>9.6.8-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>stdlib xmlunit testing support</name>
+	<description>module to support xml testing</description>
+
+	<parent>
+		<groupId>com.peterphi.std.guice</groupId>
+		<artifactId>stdlib-guice-parent</artifactId>
+		<version>9.6.8-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>jdom2</artifactId>
+			<version>2.0.6</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>xmlunit</groupId>
+			<artifactId>xmlunit</artifactId>
+			<version>1.6</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/guice/xml-testing/src/main/java/com/peterphi/std/guice/xmltesting/XMLDiffHelper.java
+++ b/guice/xml-testing/src/main/java/com/peterphi/std/guice/xmltesting/XMLDiffHelper.java
@@ -1,0 +1,72 @@
+package com.peterphi.std.guice.xmltesting;
+
+import com.peterphi.std.util.DOMUtils;
+import com.peterphi.std.util.JDOMUtils;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.junit.ComparisonFailure;
+import org.w3c.dom.Document;
+
+import java.util.Set;
+
+public class XMLDiffHelper
+{
+	public static void xmldiff(final String expectedResource, final Document actual, final Set<String> attributesToRemove)
+	{
+		final Document expected = DOMUtils.parse(XMLDiffHelper.class.getResourceAsStream(expectedResource));
+
+		xmldiff(expected, actual, attributesToRemove);
+	}
+
+
+	public static void xmldiff(final Document expected, final Document actual, final Set<String> attributesToRemove)
+	{
+		Diff diff = doXmlDiff(expected, actual, attributesToRemove);
+
+		if (!diff.similar())
+			throw new ComparisonFailure(diff.toString(), pretty(expected), pretty(actual));
+	}
+
+
+	public static Diff doXmlDiff(final Document expected, final Document actual, final Set<String> attributesToRemove)
+	{
+		XMLUnit.setIgnoreWhitespace(true);
+
+		filterDocument(expected, actual, attributesToRemove);
+
+		return new Diff(expected, actual);
+	}
+
+
+	public static void filterDocument(final Document expected, final Document actual, final Set<String> attributesToRemove)
+	{
+		XMLTestInputFilter docFilterer = new XMLTestInputFilter();
+
+		if (attributesToRemove != null)
+			docFilterer.setAttributesToRemove(attributesToRemove);
+
+		docFilterer.setRemoveComments(true);
+
+		docFilterer.apply(expected);
+		docFilterer.apply(actual);
+	}
+
+
+	/**
+	 * Pretty-print some XML
+	 *
+	 * @param doc
+	 *
+	 * @return
+	 */
+	public static String pretty(Document doc)
+	{
+		final XMLOutputter formatter = new XMLOutputter();
+		formatter.setFormat(Format.getPrettyFormat());
+
+		return formatter.outputString(JDOMUtils.convert(doc));
+	}
+}
+

--- a/guice/xml-testing/src/main/java/com/peterphi/std/guice/xmltesting/XMLTestInputFilter.java
+++ b/guice/xml-testing/src/main/java/com/peterphi/std/guice/xmltesting/XMLTestInputFilter.java
@@ -1,0 +1,93 @@
+package com.peterphi.std.guice.xmltesting;
+
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Filters XML documents to remove nodes that should not be sent to XMLUnit
+ */
+class XMLTestInputFilter
+{
+	private Set<String> attributesToRemove = new HashSet<>();
+	private boolean removeComments = false;
+
+
+	public XMLTestInputFilter()
+	{
+	}
+
+
+	public Set<String> getAttributesToRemove()
+	{
+		return attributesToRemove;
+	}
+
+
+	public void setAttributesToRemove(final Set<String> attributesToRemove)
+	{
+		this.attributesToRemove = attributesToRemove;
+	}
+
+
+	public boolean isRemoveComments()
+	{
+		return removeComments;
+	}
+
+
+	public void setRemoveComments(final boolean removeComments)
+	{
+		this.removeComments = removeComments;
+	}
+
+
+	public void apply(final Document doc)
+	{
+		apply(doc.getDocumentElement());
+	}
+
+
+	void apply(NodeList list)
+	{
+		for (int i = 0; i < list.getLength(); i++)
+		{
+			apply(list.item(i));
+		}
+	}
+
+
+	void apply(Node node)
+	{
+		if (removeComments && node instanceof org.w3c.dom.Comment)
+			node.getParentNode().removeChild(node);
+		else
+		{
+			apply(node.getChildNodes());
+
+			apply(node.getAttributes());
+		}
+	}
+
+
+	private void apply(final NamedNodeMap map)
+	{
+		if (map == null)
+			return;
+
+		Attr[] attrs = new Attr[map.getLength()];
+		for (int i = 0; i < map.getLength(); i++)
+			attrs[i] = (Attr) map.item(i);
+
+		for (Attr attr : attrs)
+		{
+			if (attributesToRemove.contains(attr.getLocalName()))
+				map.removeNamedItem(attr.getName());
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<guice.version>4.2.0</guice.version>
 		<metrics.version>4.0.2</metrics.version>
-		<resteasy.version>3.1.4.Final</resteasy.version>
+		<resteasy.version>3.5.0.Final</resteasy.version>
 		<javassist.version>3.19.0-GA</javassist.version>
 		<hibernate.version>5.2.11.Final</hibernate.version>
 		<dbunit.version>2.5.1</dbunit.version>
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.moxy</artifactId>
-			<version>2.7.0</version>
+			<version>2.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,13 @@
 		<javalang.version>1.8</javalang.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<junit.version>4.12</junit.version>
-		<httpclient.version>4.5.3</httpclient.version>
+		<httpclient.version>4.5.5</httpclient.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
 		<guice.version>4.2.0</guice.version>
 		<metrics.version>4.0.2</metrics.version>
 		<resteasy.version>3.5.0.Final</resteasy.version>
 		<javassist.version>3.19.0-GA</javassist.version>
-		<hibernate.version>5.2.11.Final</hibernate.version>
+		<hibernate.version>5.2.16.Final</hibernate.version>
 		<dbunit.version>2.5.1</dbunit.version>
 		<hsqldb.version>2.4.0</hsqldb.version>
 		<bouncycastle.version>1.55</bouncycastle.version>
@@ -208,8 +208,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
-					<source>1.9</source>
-					<target>1.9</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,7 @@
 		<junit.version>4.12</junit.version>
 		<httpclient.version>4.5.3</httpclient.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-		
-		<guice.version>3.2.6</guice.version>
-<!--		<guice.version>4.1.0</guice.version> -->
+		<guice.version>4.2.0</guice.version>
 		<metrics.version>4.0.2</metrics.version>
 		<resteasy.version>3.1.4.Final</resteasy.version>
 		<javassist.version>3.19.0-GA</javassist.version>
@@ -114,6 +112,16 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.moxy</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
@@ -132,7 +140,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.0</version>
                     <!-- Write the build number and maven artifact info to the war manifest -->
                     <configuration>
                         <archive>
@@ -153,7 +161,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.0.2</version>
 
                     <!-- Write the build number and maven artifact info to the jar manifest -->
                     <configuration>
@@ -184,7 +192,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
+				<version>2.20.1</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TestUtils.java</exclude>
@@ -198,10 +206,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.7.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>1.9</source>
+					<target>1.9</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20.1</version>
+				<version>2.21.0</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TestUtils.java</exclude>

--- a/service-manager/configuration/src/main/java/com/peterphi/configuration/service/git/ConfigCommit.java
+++ b/service-manager/configuration/src/main/java/com/peterphi/configuration/service/git/ConfigCommit.java
@@ -1,6 +1,6 @@
 package com.peterphi.configuration.service.git;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import java.util.Date;
 
@@ -24,12 +24,12 @@ public class ConfigCommit
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this)
-		              .add("timestamp", timestamp)
-		              .add("name", name)
-		              .add("email", email)
-		              .add("message",
+		return MoreObjects.toStringHelper(this)
+		                  .add("timestamp", timestamp)
+		                  .add("name", name)
+		                  .add("email", email)
+		                  .add("message",
 		                   message)
-		              .toString();
+		                  .toString();
 	}
 }

--- a/service-manager/service-manager-api/src/main/java/com/peterphi/servicemanager/service/rest/resource/type/HostnameRequestDTO.java
+++ b/service-manager/service-manager-api/src/main/java/com/peterphi/servicemanager/service/rest/resource/type/HostnameRequestDTO.java
@@ -1,6 +1,6 @@
 package com.peterphi.servicemanager.service.rest.resource.type;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -23,7 +23,7 @@ public class HostnameRequestDTO
 	@Override
 	public String toString()
 	{
-		return Objects
+		return MoreObjects
 				       .toStringHelper(this)
 				       .add("prefix", prefix)
 				       .add("hostname", hostname)

--- a/service-manager/service-manager-api/src/main/java/com/peterphi/servicemanager/service/rest/resource/type/ResourceKVP.java
+++ b/service-manager/service-manager-api/src/main/java/com/peterphi/servicemanager/service/rest/resource/type/ResourceKVP.java
@@ -1,6 +1,6 @@
 package com.peterphi.servicemanager.service.rest.resource.type;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
@@ -34,7 +34,7 @@ public class ResourceKVP
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("name", name).add("value", value).toString();
+		return MoreObjects.toStringHelper(this).add("name", name).add("value", value).toString();
 	}
 
 

--- a/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/logging/LogLineTableEntity.java
+++ b/service-manager/service-manager/src/main/java/com/peterphi/servicemanager/service/logging/LogLineTableEntity.java
@@ -1,6 +1,6 @@
 package com.peterphi.servicemanager.service.logging;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.microsoft.azure.storage.table.TableServiceEntity;
 import com.peterphi.std.types.SimpleId;
 import org.apache.commons.lang.StringUtils;
@@ -282,8 +282,8 @@ public class LogLineTableEntity extends TableServiceEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("when", when).add("category", category).add("level", level).add("endpoint",
-		                                                                                                        endpoint).add(
+		return MoreObjects.toStringHelper(this).add("when", when).add("category", category).add("level", level).add("endpoint",
+		                                                                                                            endpoint).add(
 				"instanceId",
 				instanceId).add("codeRev", codeRev).add("threadId", threadId).add("userId", userId).add("traceId", traceId).add(
 				"exceptionId",

--- a/stdlib/pom.xml
+++ b/stdlib/pom.xml
@@ -86,10 +86,5 @@
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse.persistence</groupId>
-			<artifactId>org.eclipse.persistence.moxy</artifactId>
-			<version>2.7.0</version>
-		</dependency>
 	</dependencies>
 </project>

--- a/stdlib/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
+++ b/stdlib/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/RoleEntity.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/db/entity/RoleEntity.java
@@ -1,11 +1,10 @@
 package com.peterphi.usermanager.db.entity;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -71,6 +70,6 @@ public class RoleEntity
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("id", id).add("caption", caption).toString();
+		return MoreObjects.toStringHelper(this).add("id", id).add("caption", caption).toString();
 	}
 }

--- a/user-manager/service/src/main/java/com/peterphi/usermanager/guice/authentication/ldap/LDAPGroup.java
+++ b/user-manager/service/src/main/java/com/peterphi/usermanager/guice/authentication/ldap/LDAPGroup.java
@@ -1,6 +1,6 @@
 package com.peterphi.usermanager.guice.authentication.ldap;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public class LDAPGroup
 {
@@ -38,6 +38,6 @@ public class LDAPGroup
 	@Override
 	public String toString()
 	{
-		return Objects.toStringHelper(this).add("id", id).add("dn", dn).toString();
+		return MoreObjects.toStringHelper(this).add("id", id).add("dn", dn).toString();
 	}
 }


### PR DESCRIPTION
Upgrade libraries to increase Java 9 compatibility. Also upgrade other libraries at the same time. Specifically:

 - Guice 4.2.0 (with guava 23, requiring Objects.toStringHelper -> MoreObjects.toStringHelper)
 - Hibernate 5.2.16 (from 5.2.11)
 - HTTP Client 4.5.5 (from 4.5.3)
 - xbean-finder 4.7
 - resteasy 3.5.0
 - eclipselink moxy 2.7.1 (from 2.7.0)
 - liquibase 3.5.5 (from 3.5.3)
 - dropwizard metrics 4.0.2
 - ASM 6.1
 - Various maven plugin versions updated


Also adds new module, stdlib-xml-testing which has a simple xmlunit helper